### PR TITLE
feature flags updates to config page in next app

### DIFF
--- a/client/app/settings/page.tsx
+++ b/client/app/settings/page.tsx
@@ -1,13 +1,9 @@
 import Link from "next/link"
 import * as React from "react"
-import { Button } from "@/components/ui/button"
-import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Checkbox } from "@/components/ui/checkbox"
-import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuRadioGroup, DropdownMenuRadioItem } from "@/components/ui/dropdown-menu"
-import { Switch } from "@/components/ui/switch"
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card"
 import { Navbar } from "@/components/navbar"
 import { JiraIntegrationForm } from "@/components/jira-integration-form"
+import { FeatureFlagsForm } from "@/components/feature-flags-form"
 
 export default function Component() {
   return (
@@ -20,12 +16,12 @@ export default function Component() {
         <div className="grid md:grid-cols-[180px_1fr] lg:grid-cols-[250px_1fr] items-start gap-6 max-w-6xl w-full mx-auto">
           <nav className="text-sm text-gray-500 grid gap-4 dark:text-gray-400">
             <Link href="#" className="font-semibold text-gray-900 dark:text-gray-50" prefetch={false}>
-              General
+              Integrations
             </Link>
             <Link href="#" prefetch={false}>
-              Domains
+              Features
             </Link>
-            <Link href="#" prefetch={false}>
+            {/* <Link href="#" prefetch={false}>
               Log Drains
             </Link>
             <Link href="#" prefetch={false}>
@@ -39,7 +35,7 @@ export default function Component() {
             </Link>
             <Link href="#" prefetch={false}>
               Advanced
-            </Link>
+            </Link> */}
           </nav>
           <div className="grid gap-6">
           <Card>
@@ -51,7 +47,7 @@ export default function Component() {
                 <JiraIntegrationForm />
               </CardContent>
             </Card>
-            <Card>
+            {/* <Card>
               <CardHeader>
                 <CardTitle>Root Directory</CardTitle>
                 <CardDescription>The directory within your project, in which your code is located.</CardDescription>
@@ -102,8 +98,17 @@ export default function Component() {
                   </div>
                 </div>
               </CardContent>
-            </Card>
+            </Card> */}
             <Card>
+              <CardHeader>
+                <CardTitle>Feature Flags</CardTitle>
+                <CardDescription>Enable or disable application features.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <FeatureFlagsForm />
+              </CardContent>
+            </Card>
+            {/* <Card>
               <CardHeader>
                 <CardTitle>Appearance</CardTitle>
                 <CardDescription>Choose your preferred theme and font size.</CardDescription>
@@ -187,7 +192,7 @@ export default function Component() {
                   <Switch id="third-party-cookies" />
                 </div>
               </CardContent>
-            </Card>
+            </Card> */}
           </div>
         </div>
       </main>
@@ -195,69 +200,69 @@ export default function Component() {
   )
 }
 
-function AtSignIcon(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="12" cy="12" r="4" />
-      <path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-4 8" />
-    </svg>
-  )
-}
+// function AtSignIcon(props: React.SVGProps<SVGSVGElement>) {
+//   return (
+//     <svg
+//       {...props}
+//       xmlns="http://www.w3.org/2000/svg"
+//       width="24"
+//       height="24"
+//       viewBox="0 0 24 24"
+//       fill="none"
+//       stroke="currentColor"
+//       strokeWidth="2"
+//       strokeLinecap="round"
+//       strokeLinejoin="round"
+//     >
+//       <circle cx="12" cy="12" r="4" />
+//       <path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-4 8" />
+//     </svg>
+//   )
+// }
 
 
-function BellIcon(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
-      <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
-    </svg>
-  )
-}
+// function BellIcon(props: React.SVGProps<SVGSVGElement>) {
+//   return (
+//     <svg
+//       {...props}
+//       xmlns="http://www.w3.org/2000/svg"
+//       width="24"
+//       height="24"
+//       viewBox="0 0 24 24"
+//       fill="none"
+//       stroke="currentColor"
+//       strokeWidth="2"
+//       strokeLinecap="round"
+//       strokeLinejoin="round"
+//     >
+//       <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+//       <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+//     </svg>
+//   )
+// }
 
 
-function EyeOffIcon(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
-      <path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68" />
-      <path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
-      <line x1="2" x2="22" y1="2" y2="22" />
-    </svg>
-  )
-}
+// function EyeOffIcon(props: React.SVGProps<SVGSVGElement>) {
+//   return (
+//     <svg
+//       {...props}
+//       xmlns="http://www.w3.org/2000/svg"
+//       width="24"
+//       height="24"
+//       viewBox="0 0 24 24"
+//       fill="none"
+//       stroke="currentColor"
+//       strokeWidth="2"
+//       strokeLinecap="round"
+//       strokeLinejoin="round"
+//     >
+//       <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
+//       <path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68" />
+//       <path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
+//       <line x1="2" x2="22" y1="2" y2="22" />
+//     </svg>
+//   )
+// }
 
 
 // function FrameIcon(props: React.SVGProps<SVGSVGElement>) {
@@ -283,93 +288,93 @@ function EyeOffIcon(props: React.SVGProps<SVGSVGElement>) {
 // }
 
 
-function MonitorIcon(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <rect width="20" height="14" x="2" y="3" rx="2" />
-      <line x1="8" x2="16" y1="21" y2="21" />
-      <line x1="12" x2="12" y1="17" y2="21" />
-    </svg>
-  )
-}
+// function MonitorIcon(props: React.SVGProps<SVGSVGElement>) {
+//   return (
+//     <svg
+//       {...props}
+//       xmlns="http://www.w3.org/2000/svg"
+//       width="24"
+//       height="24"
+//       viewBox="0 0 24 24"
+//       fill="none"
+//       stroke="currentColor"
+//       strokeWidth="2"
+//       strokeLinecap="round"
+//       strokeLinejoin="round"
+//     >
+//       <rect width="20" height="14" x="2" y="3" rx="2" />
+//       <line x1="8" x2="16" y1="21" y2="21" />
+//       <line x1="12" x2="12" y1="17" y2="21" />
+//     </svg>
+//   )
+// }
 
 
-function MoonIcon(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
-    </svg>
-  )
-}
+// function MoonIcon(props: React.SVGProps<SVGSVGElement>) {
+//   return (
+//     <svg
+//       {...props}
+//       xmlns="http://www.w3.org/2000/svg"
+//       width="24"
+//       height="24"
+//       viewBox="0 0 24 24"
+//       fill="none"
+//       stroke="currentColor"
+//       strokeWidth="2"
+//       strokeLinecap="round"
+//       strokeLinejoin="round"
+//     >
+//       <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+//     </svg>
+//   )
+// }
 
 
-function SunIcon(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="12" cy="12" r="4" />
-      <path d="M12 2v2" />
-      <path d="M12 20v2" />
-      <path d="m4.93 4.93 1.41 1.41" />
-      <path d="m17.66 17.66 1.41 1.41" />
-      <path d="M2 12h2" />
-      <path d="M20 12h2" />
-      <path d="m6.34 17.66-1.41 1.41" />
-      <path d="m19.07 4.93-1.41 1.41" />
-    </svg>
-  )
-}
+// function SunIcon(props: React.SVGProps<SVGSVGElement>) {
+//   return (
+//     <svg
+//       {...props}
+//       xmlns="http://www.w3.org/2000/svg"
+//       width="24"
+//       height="24"
+//       viewBox="0 0 24 24"
+//       fill="none"
+//       stroke="currentColor"
+//       strokeWidth="2"
+//       strokeLinecap="round"
+//       strokeLinejoin="round"
+//     >
+//       <circle cx="12" cy="12" r="4" />
+//       <path d="M12 2v2" />
+//       <path d="M12 20v2" />
+//       <path d="m4.93 4.93 1.41 1.41" />
+//       <path d="m17.66 17.66 1.41 1.41" />
+//       <path d="M2 12h2" />
+//       <path d="M20 12h2" />
+//       <path d="m6.34 17.66-1.41 1.41" />
+//       <path d="m19.07 4.93-1.41 1.41" />
+//     </svg>
+//   )
+// }
 
 
-function TextIcon(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M17 6.1H3" />
-      <path d="M21 12.1H3" />
-      <path d="M15.1 18H3" />
-    </svg>
-  )
-}
+// function TextIcon(props: React.SVGProps<SVGSVGElement>) {
+//   return (
+//     <svg
+//       {...props}
+//       xmlns="http://www.w3.org/2000/svg"
+//       width="24"
+//       height="24"
+//       viewBox="0 0 24 24"
+//       fill="none"
+//       stroke="currentColor"
+//       strokeWidth="2"
+//       strokeLinecap="round"
+//       strokeLinejoin="round"
+//     >
+//       <path d="M17 6.1H3" />
+//       <path d="M21 12.1H3" />
+//       <path d="M15.1 18H3" />
+//     </svg>
+//   )
+// }

--- a/client/components/feature-flags-form.tsx
+++ b/client/components/feature-flags-form.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useSession } from 'next-auth/react';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { AlertCircle, CheckCircle2 } from 'lucide-react';
+
+export function FeatureFlagsForm() {
+  const { status } = useSession();
+  
+  const [prSummariesEnabled, setPrSummariesEnabled] = useState(true);
+  const [jiraTicketEnabled, setJiraTicketEnabled] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState('');
+
+  const fetchFeatureFlags = useCallback(async () => {
+    try {
+      setLoading(true);
+      const response = await fetch(`/api/settings`);
+      
+      if (response.status === 401) {
+        // API will redirect if unauthorized due to middleware
+        return;
+      }
+      
+      const data = await response.json();
+      
+      if (data.exists) {
+        setPrSummariesEnabled(data.prSummariesEnabled !== false); // Default to true if not set
+        setJiraTicketEnabled(data.jiraTicketEnabled === true); // Default to false if not set
+      }
+    } catch (err) {
+      console.error('Error fetching feature flags:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status === 'authenticated') {
+      fetchFeatureFlags();
+    }
+  }, [status, fetchFeatureFlags]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    setSuccess(false);
+
+    try {
+      const response = await fetch('/api/settings', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          prSummariesEnabled,
+          jiraTicketEnabled
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to save settings');
+      }
+
+      setSuccess(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unknown error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Show loading state while checking authentication
+  if (status === 'loading') {
+    return (
+      <div className="flex justify-center items-center py-4">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="pr-summaries-switch" className="space-y-1">
+            <span className="text-sm font-medium leading-none">PR Summaries</span>
+            <p className="text-sm text-muted-foreground">
+              Automatically generate summaries for pull requests.
+            </p>
+          </Label>
+          <Switch 
+            id="pr-summaries-switch" 
+            checked={prSummariesEnabled}
+            onCheckedChange={setPrSummariesEnabled}
+          />
+        </div>
+        
+        <div className="flex items-center justify-between">
+          <Label htmlFor="jira-ticket-switch" className="space-y-1">
+            <span className="text-sm font-medium leading-none">Jira Ticket Integration</span>
+            <p className="text-sm text-muted-foreground">
+              Connect code changes with relevant Jira tickets.
+            </p>
+          </Label>
+          <Switch 
+            id="jira-ticket-switch" 
+            checked={jiraTicketEnabled}
+            onCheckedChange={setJiraTicketEnabled}
+          />
+        </div>
+      </div>
+      
+      {error && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      
+      {success && (
+        <Alert className="bg-green-50 text-green-800 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-900">
+          <CheckCircle2 className="h-4 w-4" />
+          <AlertDescription>Feature flags updated successfully!</AlertDescription>
+        </Alert>
+      )}
+      
+      <Button type="submit" disabled={loading}>
+        {loading ? 'Saving...' : 'Save Settings'}
+      </Button>
+    </form>
+  );
+} 

--- a/server/github/src/services/database.ts
+++ b/server/github/src/services/database.ts
@@ -69,24 +69,25 @@ export class DatabaseService {
   }
 
   /**
-   * Get feature flag settings from Firestore
+   * Get feature flag settings from Firestore for a specific user
+   * @param userId The ID of the user whose feature flags to retrieve
    * @returns A promise resolving to the feature flag settings with defaults applied
    */
-  async getFeatureFlags(): Promise<FeatureFlags> {
+  async getFeatureFlags(userId: string): Promise<FeatureFlags> {
     try {
-      // Default organization settings (could be configurable later)
-      const orgSettingsDoc = await this.db
+      // Get user-specific settings
+      const userSettingsDoc = await this.db
         .collection(config.firebase.collections.settings)
-        .doc('organization')
+        .doc(userId)
         .get();
       
-      if (!orgSettingsDoc.exists) {
-        this.logger.debug('No organization feature flags found, using defaults');
+      if (!userSettingsDoc.exists) {
+        this.logger.debug(`No feature flags found for user: ${userId}, using defaults`);
         return this.getDefaultFeatureFlags();
       }
       
-      const data = orgSettingsDoc.data();
-      this.logger.debug('Retrieved feature flags from database');
+      const data = userSettingsDoc.data();
+      this.logger.debug(`Retrieved feature flags for user: ${userId}`);
       
       // Apply defaults for any missing values
       return {
@@ -94,7 +95,7 @@ export class DatabaseService {
         jiraTicketEnabled: data?.jiraTicketEnabled === true, // Default to false if not set
       };
     } catch (error) {
-      this.logger.error('Failed to retrieve feature flags', { error });
+      this.logger.error(`Failed to retrieve feature flags for user: ${userId}`, { error });
       // Return defaults in case of error
       return this.getDefaultFeatureFlags();
     }

--- a/server/github/src/services/database.ts
+++ b/server/github/src/services/database.ts
@@ -3,6 +3,14 @@ import { getFirestore, Firestore } from 'firebase-admin/firestore';
 import { config } from '../config/index.js';
 import { Logger } from '../utils/logger.js';
 
+/**
+ * Feature flags interface
+ */
+export interface FeatureFlags {
+  prSummariesEnabled: boolean;
+  jiraTicketEnabled: boolean;
+}
+
 export class DatabaseService {
   private db: Firestore;
   private logger: Logger;
@@ -58,5 +66,48 @@ export class DatabaseService {
       jiraDomain: data?.jiraDomain || '',
       jiraApiToken: data?.jiraApiToken || ''
     };
-  } 
+  }
+
+  /**
+   * Get feature flag settings from Firestore
+   * @returns A promise resolving to the feature flag settings with defaults applied
+   */
+  async getFeatureFlags(): Promise<FeatureFlags> {
+    try {
+      // Default organization settings (could be configurable later)
+      const orgSettingsDoc = await this.db
+        .collection(config.firebase.collections.settings)
+        .doc('organization')
+        .get();
+      
+      if (!orgSettingsDoc.exists) {
+        this.logger.debug('No organization feature flags found, using defaults');
+        return this.getDefaultFeatureFlags();
+      }
+      
+      const data = orgSettingsDoc.data();
+      this.logger.debug('Retrieved feature flags from database');
+      
+      // Apply defaults for any missing values
+      return {
+        prSummariesEnabled: data?.prSummariesEnabled !== false, // Default to true if not set
+        jiraTicketEnabled: data?.jiraTicketEnabled === true, // Default to false if not set
+      };
+    } catch (error) {
+      this.logger.error('Failed to retrieve feature flags', { error });
+      // Return defaults in case of error
+      return this.getDefaultFeatureFlags();
+    }
+  }
+  
+  /**
+   * Get default feature flag values
+   * @returns The default feature flag values
+   */
+  private getDefaultFeatureFlags(): FeatureFlags {
+    return {
+      prSummariesEnabled: true,  // PR summaries enabled by default
+      jiraTicketEnabled: false,  // Jira ticket integration disabled by default
+    };
+  }
 }


### PR DESCRIPTION
## Summary

This pull request introduces feature flags to the settings page, allowing users to control PR summaries and Jira ticket integration.

## Changes

- Implemented feature flags for PR summaries and Jira ticket integration in the settings API, allowing users to toggle these features. This includes:
    - Adding `prSummariesEnabled` and `jiraTicketEnabled` fields to the request body and data update in the [settings API endpoint](https://github.com/push-to-prod-ai/push-to-prod/blob/fdd12a48986b9710b94e0f9857a0042e906e4f7e/client/app/api/settings/route.ts#L16-L20).
    - Updating the API to conditionally include fields based on request parameters for settings updates [here](https://github.com/push-to-prod-ai/push-to-prod/blob/fdd12a48986b9710b94e0f9857a0042e906e4f7e/client/app/api/settings/route.ts#L36-L40).
    - Including feature flag statuses in the response of the [settings API](https://github.com/push-to-prod-ai/push-to-prod/blob/fdd12a48986b9710b94e0f9857a0042e906e4f7e/client/app/api/settings/route.ts#L83-L86).
- Added a new `FeatureFlagsForm` component to manage feature flags within the settings page, enabling users to control PR summaries and Jira ticket integration directly from the UI, located in the [settings page](https://github.com/push-to-prod-ai/push-to-prod/blob/fdd12a48986b9710b94e0f9857a0042e906e4f7e/client/app/settings/page.tsx#L61-L65) and implemented in the new [Feature Flag Form component](https://github.com/push-to-prod-ai/push-to-prod/blob/fdd12a48986b9710b94e0f9857a0042e906e4f7e/client/components/feature-flags-form.tsx#L1-L140).
- Modified the GitHub app to dynamically check feature flags at runtime, ensuring features are enabled or disabled based on user settings. This includes:
    - Checking the `prSummariesEnabled` flag before processing PR summaries in the [PR handler](https://github.com/push-to-prod-ai/push-to-prod/blob/fdd12a48986b9710b94e0f9857a0042e906e4f7e/server/github/src/index.ts#L49-L57).
    - Implementing Jira ticket integration based on the `jiraTicketEnabled` flag for pull request events [here](https://github.com/push-to-prod-ai/push-to-prod/blob/fdd12a48986b9710b94e0f9857a0042e906e4f7e/server/github/src/index.ts#L171-L251).
    - Adding a `FeatureFlags` interface and `getFeatureFlags` function to retrieve these settings from Firestore in the [Database Service](https://github.com/push-to-prod-ai/push-to-prod/blob/fdd12a48986b9710b94e0f9857a0042e906e4f7e/server/github/src/services/database.ts#L52-L91).

## Impact

- Users can now control PR summary generation and Jira ticket integration via feature flags, configurable in the settings page, impacting the behavior of the [PR summary generation](https://github.com/push-to-prod-ai/push-to-prod/blob/fdd12a48986b9710b94e0f9857a0042e906e4f7e/server/github/src/index.ts#L49-L57) and [Jira ticket integration](https://github.com/push-to-prod-ai/push-to-prod/blob/fdd12a48986b9710b94e0f9857a0042e906e4f7e/server/github/src/index.ts#L171-L251) features.