### PR TITLE
fix blast radius build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -75,7 +75,7 @@ steps:
       - '--memory'
       - '2048Mi'
       - '--set-secrets'
-      - 'JIRA_EMAIL=push-to-prod-jira-email:latest,JIRA_API_TOKEN=push-to-prod-jira-token:latest'
+      - 'JIRA_EMAIL=push-to-prod-jira-email:latest,JIRA_API_TOKEN=push-to-prod-jira-token:latest,FIREBASE_PROJECT_ID=frontend-firebase-project-id:latest'
     waitFor: ['push-blast-radius']
 
   - id: 'deploy-syntropy'

--- a/server/blast-radius/src/database.py
+++ b/server/blast-radius/src/database.py
@@ -18,7 +18,6 @@ class Config:
         'settings': 'settings',
         'users': 'users'
     }
-    GEMINI_API_KEY = os.getenv('GEMINI_API_KEY')
 
 
 # Feature Flags
@@ -146,7 +145,7 @@ class DatabaseService:
 
 
 # Validate required environment variables
-required_env_vars = ['GEMINI_API_KEY', 'FIREBASE_PROJECT_ID']
+required_env_vars = ['FIREBASE_PROJECT_ID']
 
 for env_var in required_env_vars:
     if not os.getenv(env_var):


### PR DESCRIPTION
## fix blast radius build

### Summary
*   The build process now includes the `FIREBASE_PROJECT_ID` secret, ensuring proper configuration for Firebase deployments. This was added to the [cloudbuild.yaml file](https://github.com/push-to-prod-ai/push-to-prod/blob/60816eeb86c3b94837031d93e49ae33de9585837/cloudbuild.yaml#L75).
*   The `GEMINI_API_KEY` environment variable was removed from the required environment variables in [database.py](https://github.com/push-to-prod-ai/push-to-prod/blob/60816eeb86c3b94837031d93e49ae33de9585837/server/blast-radius/src/database.py#L146) and the `Config` class in [database.py](https://github.com/push-to-prod-ai/push-to-prod/blob/60816eeb86c3b94837031d93e49ae33de9585837/server/blast-radius/src/database.py#L18).

### Details

*   **Cloud Build Configuration**: Updated the Cloud Build configuration to include `FIREBASE_PROJECT_ID` in the set of secrets passed to the build environment. This ensures that the Firebase project ID is available during the build process, which is necessary for successful deployments.
    ```diff
    --- a/cloudbuild.yaml
    +++ b/cloudbuild.yaml
    @@ -75,7 +75,7 @@ steps:
            - '--memory'
            - '2048Mi'
            - '--set-secrets'
    -      - 'JIRA_EMAIL=push-to-prod-jira-email:latest,JIRA_API_TOKEN=push-to-prod-jira-token:latest'
    +      - 'JIRA_EMAIL=push-to-prod-jira-email:latest,JIRA_API_TOKEN=push-to-prod-jira-token:latest,FIREBASE_PROJECT_ID=frontend-firebase-project-id:latest'
      waitFor: ['push-blast-radius']
    ```
*   **Environment Variable Requirements**: Modified the list of required environment variables in `src/database.py` to remove the `GEMINI_API_KEY` and also removed it from the `Config` class. This indicates that the Gemini API key is no longer a mandatory requirement for the application to function, or that it is being handled differently.
    ```diff
    --- a/server/blast-radius/src/database.py
    +++ b/server/blast-radius/src/database.py
    @@ -18,7 +18,6 @@ class Config:
            'settings': 'settings',
            'users': 'users'
        }
    -    GEMINI_API_KEY = os.getenv('GEMINI_API_KEY')
    
    
    # Feature Flags
    @@ -146,7 +145,7 @@ async def get_prompt_templates(self, user_id: str) -> PromptTemplates:
    
    
    # Validate required environment variables
    -required_env_vars = ['GEMINI_API_KEY', 'FIREBASE_PROJECT_ID']
    +required_env_vars = ['FIREBASE_PROJECT_ID']
    
    for env_var in required_env_vars:
        if not os.getenv(env_var):
    ```
